### PR TITLE
Mathematischen Typo auf ÜB 3 behoben

### DIFF
--- a/kommalg/uebung03.tex
+++ b/kommalg/uebung03.tex
@@ -22,7 +22,7 @@ ist das von~$\mmm_0$ und~$X$ in~$\ps{A}$ erzeugte Ideal.
 einem Ring im Allgemeinen \emph{nicht} gilt:
 \[ \aaa \cap \sum_i \bbb_i = \sum_i (\aaa \cap \bbb_i). \]
 \item Zeige, dass folgende Regel aber durchaus stets gilt:
-\[ \aaa \cap \sqrt{\sum_i \bbb_i} = \sqrt{\sum_i (\aaa \cap \bbb_i)}. \]
+\[ \sqrt{\aaa} \cap \sqrt{\sum_i \bbb_i} = \sqrt{\sum_i (\aaa \cap \bbb_i)}. \]
 \end{enumerate}
 \end{aufgabe}
 


### PR DESCRIPTION
Es gibt Ideale, die keine Radikalideale sind.
