### PR TITLE
Sprossenteilaufgabe enttrivialisiert

### DIFF
--- a/kommalg/uebung08.tex
+++ b/kommalg/uebung08.tex
@@ -32,8 +32,8 @@ selbst.
 \begin{aufgabe}{m+2+2}{Ein Kriterium für Noetherianität}
 \begin{enumerate}
 \item Sei~$\aaa$ ein Ideal eines Rings~$A$ und sei~$x \in A$. Sei~$\aaa + (x)$
-endlich erzeugt. Zeige, dass es ein endlich erzeugtes Ideal~$\aaa_0$ mit~$\aaa
-+ (x) = \aaa_0 + (x)$ gibt.
+endlich erzeugt. Zeige, dass es ein endlich erzeugtes Ideal~$\aaa_0 \subset \aaa$
+mit~$\aaa + (x) = \aaa_0 + (x)$ gibt.
 \item Sei~$\ppp$ ein Ideal, das maximal mit der Eigenschaft ist,
 nicht endlich erzeugt zu sein. Zeige, dass~$\ppp$ ein Primideal ist.
 \item Zeige, dass ein Ring, in dem alle Primideale endlich erzeugt sind,


### PR DESCRIPTION
Ansonsten wäre \aaa_0 := \aaa + (x) möglich, das hilft einem bei der b) aber nicht weiter.
